### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+  packages: write
+  secrets: read
+
 jobs:
   pylint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/koval01/telegram-me/security/code-scanning/7](https://github.com/koval01/telegram-me/security/code-scanning/7)

To resolve the issue, we will add a `permissions` block at the root of the workflow file (`.github/workflows/build.yml`) to define permissions explicitly. This will apply to all jobs in the workflow unless overridden by a specific job-level `permissions` block. Based on the workflow's actions, the minimal permissions required are:

- `contents: read` for accessing repository content (e.g., checking out code).
- `packages: write` for authenticating and pushing images to Docker Hub and GitHub Container Registry.
- `secrets: read` for accessing stored secrets like `DOCKER_USERNAME`, `DOCKER_PASSWORD`, and `GITHUB_TOKEN`.

This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
